### PR TITLE
feat(dex): evolution requirements inline with evolution chain

### DIFF
--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -1,6 +1,8 @@
 "use server";
 
-import { Pokemon } from "@/lib/pkmn/pkmn.schema";
+import { EvolutionChain, EvolutionChainLink, EvolutionDetail } from "@/lib/pkmn/evo/evolution.schema";
+import { NamedResource, Pokemon } from "@/lib/pkmn/pkmn.schema";
+import { evolutionMethodToDisplay } from "@/lib/pkmn/pkmn.utils";
 import { PokemonSpecies } from "@/lib/pkmn/species/species.schema";
 
 export async function fetchPkmnAndSpeciesData(name: string): Promise<{ pkmn: Pokemon; species: PokemonSpecies }> {
@@ -30,4 +32,52 @@ export async function fetchPkmnAndSpeciesData(name: string): Promise<{ pkmn: Pok
         pkmn,
         species,
     };
+}
+
+export async function fetchEvolutionChain(
+    name: string
+): Promise<{ evolutions: Record<string, EvolutionDetail[]>; grouping: string }> {
+    const evolutions: Record<string, EvolutionDetail[]> = {};
+
+    try {
+        const { species } = await fetchPkmnAndSpeciesData(name);
+
+        const evoRes = await fetch(species.evolution_chain.url);
+        if (!evoRes.ok) {
+            throw new Error("Could not fetch species' evolution chain.");
+        }
+
+        const evo = (await evoRes.json()) as EvolutionChain;
+
+        const recursiveEvoDiscovery = (chain: EvolutionChainLink): string => {
+            evolutions[chain.species.name] = chain.evolution_details;
+
+            if (chain.evolves_to.length === 0) {
+                return chain.species.name;
+            }
+
+            const layer: string[] = [];
+
+            for (let i = 0; i < chain.evolves_to.length; i++) {
+                layer.push(recursiveEvoDiscovery(chain.evolves_to[i]));
+            }
+
+            return chain.species.name + "," + layer.join("|");
+        };
+
+        const grouping = recursiveEvoDiscovery(evo.chain);
+
+        console.log({ otherGrouping: grouping });
+
+        return {
+            evolutions,
+            grouping,
+        };
+    } catch (e) {
+        console.error(`Error fetching evolution chain for ${name}: ${e}`);
+        return {
+            evolutions,
+            grouping: "",
+        };
+    }
 }

--- a/src/app/api/dev/level-methods/route.ts
+++ b/src/app/api/dev/level-methods/route.ts
@@ -1,11 +1,11 @@
 import { NamedResource } from "@/lib/pkmn/pkmn.types";
 
 export async function GET() {
-    const res = await fetch(`https://pokeapi.co/api/v2/move-learn-method/?limit=1000`);
+    const res = await fetch(`https://pokeapi.co/api/v2/evolution-trigger/other`);
 
-    const { results } = await res.json();
+    const { pokemon_species } = await res.json();
 
-    const names = results.map((r: NamedResource) => `case "${r.name}": return`);
+    const names = pokemon_species.map((r: NamedResource) => `case "${r.name}": return;`);
 
     return new Response(names.join("\n"));
 }

--- a/src/app/evo/page.tsx
+++ b/src/app/evo/page.tsx
@@ -1,0 +1,36 @@
+import { evolutionBreakdown } from "@/lib/pkmn/pkmn.utils";
+import { fetchEvolutionChain } from "../actions";
+import PkmnLink from "@/components/pkmn/PkmnLink";
+import { MoveRight } from "lucide-react";
+import React from "react";
+
+export default async function EvolutionPage() {
+    const { evolutions, grouping } = await fetchEvolutionChain("eevee");
+
+    const evoBreakdown = evolutionBreakdown(evolutions, grouping);
+
+    return (
+        <div className="p-4">
+            <p className="flex flex-row items-start justify-center gap-2 flex-wrap leading-none">
+                {evoBreakdown.map((ev, i) => {
+                    return (
+                        <React.Fragment key={"ev_" + i + "_" + ev.species}>
+                            <span className="inline-flex flex-col items-center pt-1 w-min">
+                                <PkmnLink pkmnName={ev.species} />
+                                {ev.techniques && ev.techniques.length > 0 ? (
+                                    <span className="text-xs text-center">({ev.techniques.join(", or ")})</span>
+                                ) : null}
+                            </span>
+                            {!ev.or ? (
+                                <MoveRight className="h-7" size={16} />
+                            ) : i === evoBreakdown.length - 1 ? null : (
+                                <span className="pt-1"> or </span>
+                            )}
+                        </React.Fragment>
+                    );
+                })}
+            </p>
+            {/* <pre>{JSON.stringify(evoBreakdown, null, 2)}</pre> */}
+        </div>
+    );
+}

--- a/src/app/pkmn/[name]/page.tsx
+++ b/src/app/pkmn/[name]/page.tsx
@@ -1,4 +1,4 @@
-import { fetchPkmnAndSpeciesData } from "@/app/actions";
+import { fetchEvolutionChain, fetchPkmnAndSpeciesData } from "@/app/actions";
 import EvolutionList from "@/components/pkmn/evo/EvolutionList";
 import MovesList from "@/components/pkmn/moves/MovesList";
 import PkmnLink from "@/components/pkmn/PkmnLink";
@@ -60,6 +60,8 @@ export default async function Page({ params }: PkmnPageProps) {
 
     const spriteURL = getSpriteURL(id);
 
+    const { evolutions, grouping } = await fetchEvolutionChain(name);
+
     return (
         <div className="flex flex-col items-center gap-6 px-3 pb-4">
             <div className="text-center">
@@ -70,7 +72,7 @@ export default async function Page({ params }: PkmnPageProps) {
                 <PkmnTypeChip kind={type1 as PkmnType} />
                 {type2 ? <PkmnTypeChip kind={type2 as PkmnType} /> : null}
             </div>
-            <EvolutionList chain={chain as EvolutionChainLink} />
+            <EvolutionList evolutions={evolutions} grouping={grouping} />
             <Stats data={stats} />
             <MovesList moves={movesListByVersion(moves)} />
         </div>

--- a/src/app/pkmn/[name]/page.tsx
+++ b/src/app/pkmn/[name]/page.tsx
@@ -4,6 +4,7 @@ import MovesList from "@/components/pkmn/moves/MovesList";
 import PkmnLink from "@/components/pkmn/PkmnLink";
 import Stats from "@/components/pkmn/Stats";
 import PkmnTypeChip from "@/components/pkmn/types/PkmnTypeChip";
+import { EvolutionChain, EvolutionChainLink } from "@/lib/pkmn/evo/evolution.schema";
 import { Evolution, Move, NamedResource, PkmnName, PkmnType } from "@/lib/pkmn/pkmn.types";
 import { getSpriteURL, movesListByVersion } from "@/lib/pkmn/pkmn.utils";
 import { Metadata, ResolvingMetadata } from "next";
@@ -49,7 +50,7 @@ export default async function Page({ params }: PkmnPageProps) {
         throw new Error(`Error fetching evolution chain: ${name}`);
     }
 
-    const { chain } = await evoChainRes.json();
+    const { chain } = (await evoChainRes.json()) as EvolutionChain;
 
     // process data into useable forms
     const displayName = displayNames.find((dn: PkmnName) => dn.language.name === "en")?.name;
@@ -69,7 +70,7 @@ export default async function Page({ params }: PkmnPageProps) {
                 <PkmnTypeChip kind={type1 as PkmnType} />
                 {type2 ? <PkmnTypeChip kind={type2 as PkmnType} /> : null}
             </div>
-            <EvolutionList chain={chain} />
+            <EvolutionList chain={chain as EvolutionChainLink} />
             <Stats data={stats} />
             <MovesList moves={movesListByVersion(moves)} />
         </div>

--- a/src/components/pkmn/PkmnList.tsx
+++ b/src/components/pkmn/PkmnList.tsx
@@ -60,7 +60,10 @@ interface PkmnListProps {
 export default function PkmnList({ items }: PkmnListProps) {
     const [search, setSearch] = useState<string>("");
 
-    const roster = search.trim() === "" ? items : items.filter(({ name }) => name.name.indexOf(search) > -1);
+    const roster =
+        search.trim() === ""
+            ? items
+            : items.filter(({ name }) => name.name.toLowerCase().indexOf(search.toLowerCase()) > -1);
 
     return (
         <div className="w-full max-w-xl flex flex-col gap-3">

--- a/src/components/pkmn/evo/EvolutionList.tsx
+++ b/src/components/pkmn/evo/EvolutionList.tsx
@@ -1,71 +1,50 @@
 "use client";
 
 // import { Evolution } from "@/lib/pkmn/pkmn.types";
-import { EvolutionChain, EvolutionChainLink } from "@/lib/pkmn/evo/evolution.schema";
+import { EvolutionChainLink, EvolutionDetail } from "@/lib/pkmn/evo/evolution.schema";
 
 import PkmnLink from "../PkmnLink";
+import { evolutionBreakdown } from "@/lib/pkmn/pkmn.utils";
+import React from "react";
+import { MoveRight } from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 
 interface EvolutionListProps {
-    chain: EvolutionChainLink;
+    evolutions: Record<string, EvolutionDetail[]>;
+    grouping: string;
 }
 
-export default function EvolutionList({ chain }: EvolutionListProps) {
-    const evolutionChain = (chain: EvolutionChainLink): string => {
-        const evo = (next_evo: EvolutionChainLink | EvolutionChainLink[]): string | undefined => {
-            // if the evolution is an array of optionals,
-            // join them after recursively checking their downstream evolutions
-            if (Array.isArray(next_evo)) {
-                if (next_evo.length === 0) {
-                    return undefined;
-                }
-
-                // join the parallel evolution branches with an or-like separator
-                return next_evo.map((ev: EvolutionChainLink) => evo(ev)).join("|");
-            } else if (next_evo.evolves_to === null || next_evo.evolves_to === undefined) {
-                return next_evo.species?.name ?? "???";
-            }
-
-            // otherwise, join this chain into one string
-            const then = evo(next_evo.evolves_to);
-
-            return `${next_evo.species?.name}${then ? `,${then}` : ""}`;
-        };
-
-        // if top level evolution is an empty array or nothing, return only the species' name
-        if (!chain.evolves_to || (Array.isArray(chain.evolves_to) && chain.evolves_to.length === 0)) {
-            return chain.species?.name ?? "???";
-        }
-
-        // there must otherwise be an evolution, so recursively work through it
-        return `${chain.species?.name ?? "???"},${evo(chain.evolves_to)}`;
-    };
-
-    const evolutions = evolutionChain(chain).split(",");
+export default function EvolutionList({ evolutions, grouping }: EvolutionListProps) {
+    const evoBreakdown = evolutionBreakdown(evolutions, grouping);
 
     return (
-        <div className=" gap-1 justify-center">
-            {evolutions.map((ev, i) => {
-                if (ev.indexOf("|") > -1) {
-                    return (
-                        <span key={`${ev}_option_${i}`}>
-                            {ev.split("|").map((or, j) => (
-                                <span key={or + "_ev_" + j}>
-                                    {j > 0 ? " or " : " then "}
-                                    <PkmnLink pkmnName={or} />
+        <Card className="gap-1 justify-center w-full">
+            <CardHeader>
+                <CardTitle>Evolutions</CardTitle>
+            </CardHeader>
+            <CardContent>
+                <p className="flex flex-row items-start justify-center gap-2 flex-wrap leading-none">
+                    {evoBreakdown.map((ev, i) => {
+                        return (
+                            <React.Fragment key={"ev_" + i + "_" + ev.species}>
+                                <span className="inline-flex flex-col items-center pt-1 w-min">
+                                    <PkmnLink pkmnName={ev.species} />
+                                    {ev.techniques && ev.techniques.length > 0 ? (
+                                        <span className="text-xs text-center">
+                                            ({ev.techniques.join(", or ").trim()})
+                                        </span>
+                                    ) : null}
                                 </span>
-                            ))}
-                        </span>
-                    );
-                }
-                return (
-                    <span key={`${ev}_evo_${i}`}>
-                        {evolutions.length === 1 ? "just " : null}
-                        {i > 0 ? " then " : null}
-                        <PkmnLink pkmnName={ev} />
-                        {i < evolutions.length - 1 ? "," : ""}
-                    </span>
-                );
-            })}
-        </div>
+                                {i === evoBreakdown.length - 1 ? null : !ev.or ? (
+                                    <MoveRight className="h-7" size={16} />
+                                ) : (
+                                    <span className="pt-1"> or </span>
+                                )}
+                            </React.Fragment>
+                        );
+                    })}
+                </p>
+            </CardContent>
+        </Card>
     );
 }

--- a/src/components/pkmn/evo/EvolutionList.tsx
+++ b/src/components/pkmn/evo/EvolutionList.tsx
@@ -1,15 +1,17 @@
 "use client";
 
-import { Evolution } from "@/lib/pkmn/pkmn.types";
+// import { Evolution } from "@/lib/pkmn/pkmn.types";
+import { EvolutionChain, EvolutionChainLink } from "@/lib/pkmn/evo/evolution.schema";
+
 import PkmnLink from "../PkmnLink";
 
 interface EvolutionListProps {
-    chain: Evolution;
+    chain: EvolutionChainLink;
 }
 
 export default function EvolutionList({ chain }: EvolutionListProps) {
-    const evolutionChain = (chain: Evolution): string => {
-        const evo = (next_evo: Evolution | Evolution[]): string | undefined => {
+    const evolutionChain = (chain: EvolutionChainLink): string => {
+        const evo = (next_evo: EvolutionChainLink | EvolutionChainLink[]): string | undefined => {
             // if the evolution is an array of optionals,
             // join them after recursively checking their downstream evolutions
             if (Array.isArray(next_evo)) {
@@ -18,7 +20,7 @@ export default function EvolutionList({ chain }: EvolutionListProps) {
                 }
 
                 // join the parallel evolution branches with an or-like separator
-                return next_evo.map((ev: Evolution) => evo(ev)).join("|");
+                return next_evo.map((ev: EvolutionChainLink) => evo(ev)).join("|");
             } else if (next_evo.evolves_to === null || next_evo.evolves_to === undefined) {
                 return next_evo.species?.name ?? "???";
             }

--- a/src/lib/pkmn/pkmn.consts.ts
+++ b/src/lib/pkmn/pkmn.consts.ts
@@ -1,4 +1,4 @@
-import { PkmnMoveMethod, PkmnType, PkmnVersion } from "./pkmn.types";
+import { EvolutionMethod, PkmnMoveMethod, PkmnType, PkmnVersion } from "./pkmn.types";
 
 export const TYPE_NAMES: PkmnType[] = [
     "normal",
@@ -65,4 +65,20 @@ export const MOVE_METHODS: PkmnMoveMethod[] = [
     "xd-purification",
     "form-change",
     "zygarde-cube",
+];
+
+export const EVOLUTION_METHODS: EvolutionMethod[] = [
+    "level-up",
+    "trade",
+    "use-item",
+    "shed",
+    "spin",
+    "tower-of-darkness",
+    "tower-of-waters",
+    "three-critical-hits",
+    "take-damage",
+    "other",
+    "agile-style-move",
+    "strong-style-move",
+    "recoil-damage",
 ];

--- a/src/lib/pkmn/pkmn.types.ts
+++ b/src/lib/pkmn/pkmn.types.ts
@@ -101,6 +101,21 @@ export type PkmnMoveMethod =
     | "form-change"
     | "zygarde-cube";
 
+export type EvolutionMethod =
+    | "level-up"
+    | "trade"
+    | "use-item"
+    | "shed"
+    | "spin"
+    | "tower-of-darkness"
+    | "tower-of-waters"
+    | "three-critical-hits"
+    | "take-damage"
+    | "other"
+    | "agile-style-move"
+    | "strong-style-move"
+    | "recoil-damage";
+
 export type Evolution = {
     evolves_to?: Evolution | Evolution[] | null;
     species?: PkmnName | null;


### PR DESCRIPTION
- **fix(search): standardize search string**
- **feat(dex): add evolution requirements in chain**

## Description

Evolution requirements are now shown inline with the evolution chain, which has also been visually spruced up. More succinct formatting and consolidation with other fields.

For most pkmn, it works pretty well. For weird acceptions like Eevee, it leaves something to be desired. Eevee has many branching paths, and many unique evolution opportunities, so this is to be expected. What's present will be good enough for now.

